### PR TITLE
feat: add include-directories parameter to gemini bridge

### DIFF
--- a/server/gemini/index.js
+++ b/server/gemini/index.js
@@ -116,7 +116,12 @@ const handlers = {
               "developer-instructions": { type: "string", description: "Expert system instructions" },
               sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only" },
               cwd: { type: "string", description: "Current working directory" },
-              model: { type: "string", default: DEFAULT_MODEL }
+              model: { type: "string", default: DEFAULT_MODEL },
+              "include-directories": {
+                type: "array",
+                items: { type: "string" },
+                description: "Additional directories to include in the workspace alongside cwd. Equivalent to --include-directories on the Gemini CLI."
+              }
             },
             required: ["prompt"]
           }
@@ -130,7 +135,12 @@ const handlers = {
               threadId: { type: "string", description: "Session ID returned by a previous gemini call" },
               prompt: { type: "string", description: "Follow-up prompt" },
               sandbox: { type: "string", enum: ["read-only", "workspace-write"], default: "read-only" },
-              cwd: { type: "string" }
+              cwd: { type: "string" },
+              "include-directories": {
+                type: "array",
+                items: { type: "string" },
+                description: "Additional directories to include in the workspace alongside cwd. Equivalent to --include-directories on the Gemini CLI."
+              }
             },
             required: ["threadId", "prompt"]
           }
@@ -162,6 +172,18 @@ const handlers = {
       if (shouldRespond) sendError(id, -32602, "Invalid params: 'cwd' must be a non-empty string when provided");
       return;
     }
+    if (args["include-directories"] !== undefined) {
+      if (!Array.isArray(args["include-directories"]) || args["include-directories"].length === 0) {
+        if (shouldRespond) sendError(id, -32602, "Invalid params: 'include-directories' must be a non-empty array of strings when provided");
+        return;
+      }
+      for (const dir of args["include-directories"]) {
+        if (!isNonEmptyString(dir)) {
+          if (shouldRespond) sendError(id, -32602, "Invalid params: each entry in 'include-directories' must be a non-empty string");
+          return;
+        }
+      }
+    }
 
     try {
       const geminiArgs = [];
@@ -180,6 +202,9 @@ const handlers = {
         }
 
         geminiArgs.push("-m", args.model || DEFAULT_MODEL);
+        if (args["include-directories"]) {
+          geminiArgs.push("--include-directories", args["include-directories"].join(","));
+        }
         if (args.sandbox === "workspace-write") geminiArgs.push("-s");
         let prompt = args.prompt;
         if (args["developer-instructions"]) prompt = `${args["developer-instructions"]}\n\n${prompt}`;
@@ -200,6 +225,9 @@ const handlers = {
         }
 
         geminiArgs.push("--resume", threadId);
+        if (args["include-directories"]) {
+          geminiArgs.push("--include-directories", args["include-directories"].join(","));
+        }
         if (args.sandbox === "workspace-write") geminiArgs.push("-s");
         geminiArgs.push("-p", args.prompt);
       } else {


### PR DESCRIPTION
## Problem

The Gemini bridge runs the Gemini CLI with no awareness of files outside the `cwd` passed to a tool call. In practice this means callers wanting Gemini to consult specs, plans, or shared notes that live elsewhere on disk have to repack the file content inline into the prompt — which is slow, lossy for larger files, and burns context.

The Gemini CLI itself supports this natively via `--include-directories`:

```
--include-directories  Additional directories to include in the workspace
                       (comma-separated or multiple --include-directories)
                       [array]
```

…but the bridge in `server/gemini/index.js` doesn't expose it.

## Solution

Add an `include-directories` parameter to the bridge's MCP surface, mirroring the existing parameter conventions (`developer-instructions` for the kebab-case form; per-call optional like `cwd`/`sandbox`/`model`).

- Add `include-directories` (array of strings) to the `inputSchema` for both `gemini` and `gemini-reply`.
- Validate in the shared param-checking block: if provided, must be a non-empty array, and each entry must be a non-empty string.
- Wire through to the Gemini CLI by joining entries with commas and pushing as a single `--include-directories <paths>` arg pair, in both the new-session and `--resume` branches.

Backwards compatible — the parameter is optional; existing callers see no change in behavior.

## Testing

Verified by piping raw JSON-RPC through the bridge (`node server/gemini/index.js`):

| Case | Expected | Result |
|------|----------|--------|
| `initialize` | server starts, returns serverInfo | ✓ |
| `tools/list` | both tools include `include-directories` in inputSchema | ✓ |
| `include-directories: []` | error -32602 `must be a non-empty array of strings` | ✓ |
| `include-directories: \"/tmp\"` (string, not array) | error -32602 `must be a non-empty array of strings` | ✓ |
| `include-directories: [\"/tmp\", 42]` (mixed types) | error -32602 `each entry must be a non-empty string` | ✓ |
| `include-directories: [\"\"]` (empty string entry) | error -32602 `each entry must be a non-empty string` | ✓ |

Live invocation against a real `gemini` call was not exercised in this PR; happy to share a transcript if useful.

## Notes

- Naming: `include-directories` (kebab-case) matches the existing `developer-instructions` precedent for multi-word params and mirrors the Gemini CLI flag name.
- Wire format: comma-joined into a single `--include-directories <paths>` arg pair. The CLI accepts both that form and repeated `--include-directories` flags; the comma form keeps `geminiArgs` shorter.
- The same validation lives once in the shared block, so adding the parameter to a future tool only needs schema + wire-up.

🤖 Generated by [robots](https://vyos.io)